### PR TITLE
Parallel

### DIFF
--- a/lib/turbo-sprockets/sprockets_overrides/base.rb
+++ b/lib/turbo-sprockets/sprockets_overrides/base.rb
@@ -6,18 +6,19 @@ module Sprockets
 
     def build_asset(logical_path, pathname, options)
       pathname = Pathname.new(pathname)
+      #puts "build_asset: #{pathname} #{options.inspect}"
 
       # If there are any processors to run on the pathname, use
       # `BundledAsset`. Otherwise use `StaticAsset` and treat is as binary.
       if attributes_for(pathname).processors.any?
         if options[:bundle] == false
-          circular_call_protection(pathname.to_s) do
+          #circular_call_protection(pathname.to_s) do
             if options[:process] == false
               UnprocessedAsset.new(index, logical_path, pathname)
             else
               ProcessedAsset.new(index, logical_path, pathname)
             end
-          end
+          #end
         else
           BundledAsset.new(index, logical_path, pathname, options)
         end

--- a/lib/turbo-sprockets/sprockets_overrides/static_compiler.rb
+++ b/lib/turbo-sprockets/sprockets_overrides/static_compiler.rb
@@ -31,7 +31,7 @@ if defined?(Sprockets::StaticCompiler)
         logical_paths = []
         logical_paths = env.each_logical_path(paths).to_a
 
-        results = Parallel.map(logical_paths, in_processes: 8) do |logical_path|
+        results = Parallel.map(logical_paths, in_processes: ENV.fetch("PARALLEL_SPROCKETS_PROCESSORS", Parallel.processor_count).to_i) do |logical_path|
           result = {}
           # Fetch asset without any processing or compression,
           # to calculate a digest of the concatenated source files

--- a/lib/turbo-sprockets/sprockets_overrides/static_compiler.rb
+++ b/lib/turbo-sprockets/sprockets_overrides/static_compiler.rb
@@ -31,7 +31,7 @@ if defined?(Sprockets::StaticCompiler)
         logical_paths = []
         logical_paths = env.each_logical_path(paths).to_a
 
-        results = Parallel.map(logical_paths, in_processes: 4) do |logical_path|
+        results = Parallel.map(logical_paths, in_processes: 8) do |logical_path|
           result = {}
           # Fetch asset without any processing or compression,
           # to calculate a digest of the concatenated source files


### PR DESCRIPTION
creating this so I can track issues somewhere for now
- [x] compass-rails uses `asset.write_to` in `lib/compass-rails/railsties/3_1.rb`, if that gets called multiple times at the same time for the same sprite it will fail.
- [x] Sprite generation is broken, two issues (at least), the first is that things do not  get written to the manifest because of the hacks done by `compass-rails` do not work when parallelized, we need something to pull the manifest entries placed in `Sprockets::StaticCompiler.generated_sprites` out in each iteration. Also there is likely a race condition here due to the awkward clearing of `HIke::Index` mentioned in compass-rails. The solution would probably be to somehow precompile a file with all the sprites in it first in the main thread before forking. This would obviously be a giant hack.
